### PR TITLE
Use consistent words for add-on

### DIFF
--- a/locale/en-US/bootstrap.properties
+++ b/locale/en-US/bootstrap.properties
@@ -1,9 +1,9 @@
 addon_name=Chrome-Store-Foxified
 addon_description=Enables user defined mouse action combinations to trigger customizable functions
 
-addon-installed-userdisabled=Addon was succesfully installed, but you have it set as disabled, please go enable it from Addon manager.
-addon-installed-appdisabled=Addon failed to install because this version of Firefox is not compatible with it.
-addon-installed=Addon was succesfully installed.
-addon-install-failed=Addon failed to install with error code: 
+addon-installed-userdisabled=Add-on was succesfully installed, but you have it set as disabled, please go enable it from Add-ons Manager.
+addon-installed-appdisabled=Add-on failed to install because this version of Firefox is not compatible with it.
+addon-installed=Add-on was succesfully installed.
+addon-install-failed=Add-on failed to install with error code: 
 
 xpi_suffix=- Chrome Version

--- a/locale/en-US/inlay.properties
+++ b/locale/en-US/inlay.properties
@@ -1,7 +1,7 @@
 add_to_firefox=Add to Firefox
 starting=Download Started
 
-failed_isntall=Failed to download and install extension, please report to addon author. Here is the error, see browser console for more readable version:
+failed_isntall=Failed to download and install extension, please report to the addon author. Here is the error, see browser console for more readable version:
 
 error1=ERROR: Could not find extension id, will not try to install from href
 error2=ERROR: Could not find extension id, will not try to install


### PR DESCRIPTION
See:
https://transvision.mozfr.org/?recherche=addon&repo=aurora&sourcelocale=en-US&search_type=strings
https://transvision.mozfr.org/?recherche=Add-on&repo=aurora&sourcelocale=en-US&search_type=strings

I keep this "addon" of failed_isntall, I'm not sure right term for it.